### PR TITLE
Missing .envrc file caused error for direnv allow command

### DIFF
--- a/README_DEV.md
+++ b/README_DEV.md
@@ -29,7 +29,7 @@
   - Change directory to `giessdenkiez-de-postgres-api` repository, make sure you have checked out the `master` branch
   - `nvm install && nvm use`
   - `npm ci`
-  - `cp .env.sample .env`
+  - `cp .env.example .env`
   - Load the `.env` file: `direnv allow`
   - `npx supabase start` which will start a local [Supabase](https://supabase.com/) instance
   - Now the Postgres database (and all other Supabase services) are running locally in Docker containers

--- a/README_DEV.md
+++ b/README_DEV.md
@@ -29,8 +29,8 @@
   - Change directory to `giessdenkiez-de-postgres-api` repository, make sure you have checked out the `master` branch
   - `nvm install && nvm use`
   - `npm ci`
-  - `cp .env.example .env`
-  - Load the `.env` file: `direnv allow`
+  - `cp .env.example .envrc`
+  - Load the `.envrc` file: `direnv allow`
   - `npx supabase start` which will start a local [Supabase](https://supabase.com/) instance
   - Now the Postgres database (and all other Supabase services) are running locally in Docker containers
   - To see all local Supabase credentials and tokens, use `npx supabase status`


### PR DESCRIPTION
"`direnv allow`" failed earlier with message 

> direnv: error .envrc file not found



now `.env.example` file is copied to file `.envrc` and `direnv allow` runs without issues.
